### PR TITLE
Minor memory allocation optimization

### DIFF
--- a/raytracer/src/materials/lights/diffuse_light.rs
+++ b/raytracer/src/materials/lights/diffuse_light.rs
@@ -23,6 +23,11 @@ impl Material for DiffuseLight {
     }
 }
 
+pub enum Options {
+    Texture(Arc<dyn Texture>),
+    Clr(Color)
+}
+
 //TODO: Figure out a way to overload new to take an argument of texture or a color
 impl DiffuseLight {
     pub fn new(c: Color) -> DiffuseLight {
@@ -33,5 +38,12 @@ impl DiffuseLight {
 
     pub fn new_with_texture(emit: Arc<dyn Texture>) -> DiffuseLight {
         DiffuseLight { emit }
+    }
+
+    pub fn new_tex(opt: Options) -> DiffuseLight {
+        match opt {
+            Options::Texture(emit) => DiffuseLight{ emit },
+            Options::Clr(c) => DiffuseLight { emit: Arc::new(SolidColor::new(c))}
+        }
     }
 }

--- a/raytracer/src/materials/lights/diffuse_light.rs
+++ b/raytracer/src/materials/lights/diffuse_light.rs
@@ -25,7 +25,7 @@ impl Material for DiffuseLight {
 
 pub enum Options {
     Texture(Arc<dyn Texture>),
-    Clr(Color)
+    Clr(Color),
 }
 
 //TODO: Figure out a way to overload new to take an argument of texture or a color
@@ -42,8 +42,10 @@ impl DiffuseLight {
 
     pub fn new_tex(opt: Options) -> DiffuseLight {
         match opt {
-            Options::Texture(emit) => DiffuseLight{ emit },
-            Options::Clr(c) => DiffuseLight { emit: Arc::new(SolidColor::new(c))}
+            Options::Texture(emit) => DiffuseLight { emit },
+            Options::Clr(c) => DiffuseLight {
+                emit: Arc::new(SolidColor::new(c)),
+            },
         }
     }
 }

--- a/raytracer/src/renderer.rs
+++ b/raytracer/src/renderer.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 /// To handle the multi-sampled color computation - rather than adding in a fractional contribution
 /// each time we accumulate more light to the color, just add the full color each iteration, and
 /// then perform a single divide at the end (by the number of samples) when writing out the color.
-fn get_color(pixel_color: &Color, samples_per_pixel: u32) -> Vec<u8> {
+fn write_color(pixel: &mut[u8], pixel_color: &Color, samples_per_pixel: u32) {
     let mut r = pixel_color.x();
     let mut g = pixel_color.y();
     let mut b = pixel_color.z();
@@ -27,12 +27,10 @@ fn get_color(pixel_color: &Color, samples_per_pixel: u32) -> Vec<u8> {
     b = f64::sqrt(scale * b);
 
     // Write the translated [0,255] value of each color component
-    let r = (256.0 * clamp(r, 0.0, 0.999)) as u8;
-    let g = (256.0 * clamp(g, 0.0, 0.999)) as u8;
-    let b = (256.0 * clamp(b, 0.0, 0.999)) as u8;
-
-    // Compose an rgba vec
-    vec![r, g, b, 255]
+    pixel[0] = (256.0 * clamp(r, 0.0, 0.999)) as u8;
+    pixel[1] = (256.0 * clamp(g, 0.0, 0.999)) as u8;
+    pixel[2] = (256.0 * clamp(b, 0.0, 0.999)) as u8;
+    pixel[3] = 255;
 }
 
 /// # Antialiasing
@@ -87,7 +85,7 @@ where
             progress_callback((prev_value + 1) as f64 / iters as f64 * 100.0);
         }
 
-        chk.clone_from_slice(&*get_color(&pixel_color, settings.samples_per_pixel));
+        write_color(chk, &pixel_color, settings.samples_per_pixel);
     });
 
     imout

--- a/raytracer/src/renderer.rs
+++ b/raytracer/src/renderer.rs
@@ -15,16 +15,13 @@ use std::sync::Arc;
 /// To handle the multi-sampled color computation - rather than adding in a fractional contribution
 /// each time we accumulate more light to the color, just add the full color each iteration, and
 /// then perform a single divide at the end (by the number of samples) when writing out the color.
+#[inline]
 fn write_color(pixel: &mut[u8], pixel_color: &Color, samples_per_pixel: u32) {
-    let mut r = pixel_color.x();
-    let mut g = pixel_color.y();
-    let mut b = pixel_color.z();
-
     // Divide the color by the number of samples and gamma correct for gamma = 2.0.
     let scale = 1.0 / samples_per_pixel as f64;
-    r = f64::sqrt(scale * r);
-    g = f64::sqrt(scale * g);
-    b = f64::sqrt(scale * b);
+    let r = f64::sqrt(scale * pixel_color.x());
+    let g = f64::sqrt(scale * pixel_color.y());
+    let b = f64::sqrt(scale * pixel_color.z());
 
     // Write the translated [0,255] value of each color component
     pixel[0] = (256.0 * clamp(r, 0.0, 0.999)) as u8;


### PR DESCRIPTION
Currently in the renderer, we are iterating over the image pixels, and flatmapping to collect into a vector, which could lead to reallocations since the capacity is not decided upfront.
But, we know the image dimensions, so can choose to allocate the memory upfront to avoid malloc calls in between. This could speed up the rendering process slightly.